### PR TITLE
Issue No. #54 [BUG FIXED] In the footer section, the copyright year should be dynamically generated instead of being statically hardcoded. 

### DIFF
--- a/JS/copyrightYear.js
+++ b/JS/copyrightYear.js
@@ -1,0 +1,4 @@
+let copyRightYear = document.getElementById("copyright-year");
+let currentDate = new Date();
+let currentYear = currentDate.getFullYear();
+copyRightYear.innerText = currentYear;

--- a/Mission.html
+++ b/Mission.html
@@ -191,7 +191,7 @@ job2  -->
 
 <footer>
     <ul>
-      <li>ISRO &copy; 2023</li>
+      <li>ISRO &copy; <span id="copyright-year"></span> </li>
       <li><a href="https://twitter.com/isro" target="_blank">Twitter</a></li>
       <li><a href="https://www.youtube.com/@isroofficial5866" target="_blank">YouTube</a></li>
       <li><a href="https://www.linkedin.com/company/isro/" target="_blank">LinkedIn</a></li>
@@ -200,7 +200,7 @@ job2  -->
     </ul>
   </footer>
 
-
+  <script src="./JS/copyrightYear.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@
 
 <footer>
     <ul>
-      <li>ISRO &copy; 2023</li>
+      <li>ISRO &copy; <span id="copyright-year"></span></li>
       <li><a href="https://twitter.com/isro" target="_blank">Twitter</a></li>
       <li><a href="https://www.youtube.com/@isroofficial5866" target="_blank">YouTube</a></li>
       <li><a href="https://www.linkedin.com/company/isro/" target="_blank">LinkedIn</a></li>
@@ -232,6 +232,6 @@
     </ul>
   </footer>
 
-
+  <script src="./JS/copyrightYear.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Closes #54 