### PR TITLE
Feat: Added Navigation Indicator for Currently Open Page

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -79,7 +79,26 @@ ul {
   padding-bottom: 2px;
   /*Inorder to add lining animation beneath every li */
 }
-
+#polarSatellite a{
+  padding-bottom: 1.2px;
+  border-bottom: 1px solid white;
+}
+#gslv a{
+  padding-bottom: 1.2px;
+  border-bottom: 1px solid white;
+}
+#LMV3  a{
+  padding-bottom: 1.2px;
+  border-bottom: 1px solid white;
+}
+#communication_satellite a{
+  padding-bottom: 1.2px;
+  border-bottom: 1px solid white;
+}
+#foreign_satellite a{
+  padding-bottom: 1.2px;
+  border-bottom: 1px solid white;
+}
 /*Menu item bottom border*/
 
 .desktop-main-menu ul li a::after {
@@ -434,6 +453,7 @@ footer ul li a:hover {
   font-size: 80px;
   margin-bottom: 15px;
   animation: fadeInUp 0.5s ease-in-out;
+  /* text-decoration: underline; */
 }
 
 .section-inner-center p {

--- a/Communication-Satelites/index.html
+++ b/Communication-Satelites/index.html
@@ -22,7 +22,7 @@
                 <li><a href="../PSLV/">Polar Satellite LV</a></li>
                 <li><a href="../GSLV/">Geo Satellite LV</a></li>
                 <li><a href="../LMV3/">Geo Satellite M3</a></li>
-                <li><a href="./">Communication Satellites</a></li>
+                <li id="communication_satellite"><a href="./">Communication Satellites</a></li>
                 <li><a href="../Foreign/">Foreign Satellites</a></li>
 
             </ul>

--- a/Foreign/index.html
+++ b/Foreign/index.html
@@ -31,7 +31,7 @@
                 <li><a href="../GSLV/">Geo Satellite LV</a></li>
                 <li><a href="../LMV3/">Geo Satellite M3</a></li>
                 <li><a href="../Communication-Satelites/">Communication Satellites</a></li>
-                <li><a href="./">Foreign Satellites</a></li>
+                <li id="foreign_satellite"><a href="./">Foreign Satellites</a></li>
 
             </ul>
         </nav>

--- a/GSLV/index.html
+++ b/GSLV/index.html
@@ -20,7 +20,7 @@
         <nav class="desktop-main-menu">
             <ul>
                 <li><a href="../PSLV/">Polar Satellite LV</a></li>
-                <li><a href="./">Geo Satellite LV</a></li>
+                <li id="gslv"><a href="./">Geo Satellite LV</a></li>
                 <li><a href="../LMV3/">Geo Satellite M3</a></li>
                 <li><a href="../Communication-Satelites/">Communication Satellites</a></li>
                 <li><a href="../Foreign/">Foreign Satellites</a></li>

--- a/LMV3/index.html
+++ b/LMV3/index.html
@@ -21,7 +21,7 @@
             <ul>
                 <li><a href="../PSLV/">Polar Satellite LV</a></li>
                 <li><a href="../GSLV/">Geo Satellite LV</a></li>
-                <li><a href="./">Geo Satellite M3</a></li>
+                <li id="LMV3"><a href="./">Geo Satellite M3</a></li>
                 <li><a href="../Communication-Satelites/">Communication Satellites</a></li>
                 <li><a href="../Foreign/">Foreign Satellites</a></li>
 

--- a/PSLV/index.html
+++ b/PSLV/index.html
@@ -19,7 +19,7 @@
         </div>
         <nav class="desktop-main-menu">
             <ul>
-                <li><a href="./">Polar Satellite LV</a></li>
+                <li id="polarSatellite"><a href="./">Polar Satellite LV</a></li>
                 <li><a href="../GSLV/">Geo Satellite LV</a></li>
                 <li><a href="../LMV3/">Geo Satellite M3</a></li>
                 <li><a href="../Communication-Satelites/">Communication Satellites</a></li>


### PR DESCRIPTION
# Pull Request Description:
Please review the changes in PR #74 

I have addressed an issue related to the navigation menu, where it was challenging for users to identify the currently open page when navigating between different web pages. To enhance the user experience and improve navigation clarity, I have added a simple yet effective feature—an underline indicator—to highlight the tab corresponding to the currently open page.
# Page1
![Screenshot 2023-10-12 191933](https://github.com/dakshsinghrathore/ISRO-web/assets/127736781/46800c80-8f55-4936-9345-83f98cc28b5d)
# Page2
![Screenshot 2023-10-12 191951](https://github.com/dakshsinghrathore/ISRO-web/assets/127736781/4c4fd718-667b-4653-ac9a-f7f598210d70)
# Page3
![page3](https://github.com/dakshsinghrathore/ISRO-web/assets/127736781/e3935eac-e062-4bd9-9a84-dba8b1641d8e)
# Page4
![page4](https://github.com/dakshsinghrathore/ISRO-web/assets/127736781/cd4446b7-2ecd-4d88-afb2-98c2ec25759e)
dakshsinghrathore/ISRO-web/assets/127736781/be1c514a-3911-455e-93b6-66673cb3ded2)
# Page5
![pg5](https://github.com/dakshsinghrathore/ISRO-web/assets/127736781/3ea19a62-1ca7-43bc-b6fd-3feb7e449e90)
