### PR TITLE
fix: resolve issue with quiz page button

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -203,6 +203,7 @@ section {
   font-size: x-large;
   font-weight: 600;
   letter-spacing: 4px;
+  color: #fff;
 }
 
 .scroll-arrow {


### PR DESCRIPTION
This PR resolve the issue with the "START QUIZ" button on quiz page. The button is in black color but it needs to be white when not hover and turned into black when hover.
Fixed the - BUG: Text Color #117